### PR TITLE
Fixed URL for Login Manager Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ this list aims to be broader and include apps from various other ecosystems in v
 - [Dynamic Wallpaper](https://github.com/dusansimic/dynamic-wallpaper) - Dynamic wallpaper creator for GNOME 42 `#python` `#libadwaita`.
 - [EasySSH](https://github.com/muriloventuroso/easyssh) - SSH connection manager `#vala`.
 - [Flatseal](https://github.com/tchx84/Flatseal) - Flatpak permission manager `#gjs` `#libadwaita`.
-- [Login Manager Settings](https://realmazharhussain.github.io/gdm-settings) - GNOME's Login Manager (GDM) settings manager `#python` `#libadwaita`.
+- [Login Manager Settings](https://gdm-settings.github.io/) - GNOME's Login Manager (GDM) settings manager `#python` `#libadwaita`.
 - [NixOS Configuration Editor](https://github.com/vlinkz/nixos-conf-editor) - Application for editing NixOS configurations `#rust` `#libadwaita`.
 - [pulse-flow](https://github.com/benwaffle/pulse-flow) - PulseAudio configuration tool with a flow graph UI `#vala`.
 - [Shell Configurator](https://gitlab.com/adeswantaTechs/shell-configurator) - GNOME Shell configuration utility with advanced settings `#gjs` `#libadwaita`.


### PR DESCRIPTION
The URL for the Login Manager Settings website was outdated. It was `https://realmazharhussain.github.io/gdm-settings/`, I updated it to `https://gdm-settings.github.io/`, which is its new URL.