### PR TITLE
Fix curly apostrophe failing awesome-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1355,7 +1355,7 @@ Clients for commercial social platforms that had their API access cut off in a w
 - [Cartridges](https://github.com/kra-mo/cartridges) - Game launcher with Steam, Lutris, Heroic, Legendary, Bottles, itch and RetroArch library import `#python` `#gtk4` `#libadwaita`.
 - [DeSmuME](https://github.com/TASEmulators/desmume) - Cross-platform Nintendo DS emulator `#c++` `#gtk3`.
 - [Epic Asset Manager](https://github.com/AchetaGames/Epic-Asset-Manager) - Unofficial client to install Unreal Engine, download and manage purchased assets, projects, plugins and games from the Epic Games Store `#rust` `#gtk4` `#libadwaita`.
-- [Faugus Game Launcher](https://flathub.org/en/apps/io.github.Faugus.faugus-launcher) - Launcher for running Windows games in Linux using community builds of Valve’s Proton `#python` `#gtk4` `#libadwaita`.
+- [Faugus Game Launcher](https://flathub.org/en/apps/io.github.Faugus.faugus-launcher) - Launcher for running Windows games in Linux using community builds of Valve's Proton `#python` `#gtk4` `#libadwaita`.
 - [Gameeky](https://github.com/tchx84/gameeky) - Application to create and play games without any code for young learners and educators `#python` `#gtk4` `#libadwaita`.
 - [Gamepad Mirror](https://flathub.org/en/apps/page.codeberg.vendillah.GamepadMirror) - Application to visualize gamepad inputs `#gjs` `#javascript` `#gtk4` `#libadwaita`.
 - [Game Server Watcher (gswatcher)](https://flathub.org/en/apps/io.github.lxndr.gswatcher) - Simple game server monitor and an administrative tool `#vala` `#gtk4` `#libadwaita`.


### PR DESCRIPTION
Replaces the curly apostrophe in the Faugus Game Launcher entry (line 1358) with a straight one. awesome-lint has failed on trunk since #458 because of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017B1XxD5H6yAcTFgi88H39S